### PR TITLE
This pull request adds the MNISTPatches class to divide a (28,28) image into a (49,4,4) one.

### DIFF
--- a/src/mnist_patches.py
+++ b/src/mnist_patches.py
@@ -1,0 +1,63 @@
+import kagglehub
+import numpy as np
+import os
+import struct
+
+
+def load_idx_images(filename):
+    with open(filename, "rb") as f:
+        _, num, rows, cols = struct.unpack(">IIII", f.read(16))
+        data = np.frombuffer(f.read(), dtype=np.uint8)
+        return data.reshape(num, rows, cols)
+
+
+def load_idx_labels(filename):
+    with open(filename, "rb") as f:
+        _, num = struct.unpack(">II", f.read(8))
+        labels = np.frombuffer(f.read(), dtype=np.uint8)
+        return labels
+
+
+def extract_patches_4x4(img, stride=4):
+    """
+    Args:
+        img: numpy array (28, 28)
+        stride: jump between parches
+
+    Returns:
+        numpy array (num_patches, 4, 4)
+    """
+    H, W = img.shape
+    patches = []
+
+    for i in range(0, H - 4 + 1, stride):
+        for j in range(0, W - 4 + 1, stride):
+            patch = img[i:i+4, j:j+4]
+            patches.append(patch)
+
+    return np.array(patches)
+
+
+class MNISTPatches:
+    def __init__(self, stride=4):
+        """Downloads dataset and prepare train images."""
+        self.stride = stride
+
+        # Descargar dataset UNA sola vez
+        path = kagglehub.dataset_download("hojjatk/mnist-dataset")
+        print("Dataset path:", path)
+
+        train_images_path = os.path.join(path, "train-images.idx3-ubyte")
+        train_labels_path = os.path.join(path, "train-labels.idx1-ubyte")
+
+        self.X_train = load_idx_images(train_images_path)
+        self.y_train = load_idx_labels(train_labels_path)
+
+    def get_image(self, idx):
+        """Returns an image 28x28 from the train set."""
+        return self.X_train[idx]
+
+    def get_patches(self, idx):
+        """Returns a 4x4 patch from the idxth image."""
+        img = self.get_image(idx)
+        return extract_patches_4x4(img, stride=self.stride)

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -1,0 +1,16 @@
+from mnist_patches import MNISTPatches
+
+if __name__ == "__main__":
+
+    mp = MNISTPatches(stride=4)
+
+    img = mp.get_image(0)
+    assert img.shape == (28, 28), f"Wrong shape for image: {img.shape}"
+    print("Image shape:", img.shape)
+
+    patches = mp.get_patches(0)
+    assert patches.shape == (49, 4, 4), f"Wrong shape for the patched image: {patches.shape}"
+    print("Patched image shape:", patches.shape)
+
+    assert patches[0].shape == (4, 4), f"Wrong patch shape: {patches[0].shape}"
+    print("First patch:\n", patches[0])


### PR DESCRIPTION
Adds the class MNISTPatches and a test script test_patches.